### PR TITLE
🩹Follow symbolic links to find the script's installation directory

### DIFF
--- a/.cspell/custom-dictionary-linux.txt
+++ b/.cspell/custom-dictionary-linux.txt
@@ -1,1 +1,2 @@
 mktemp
+readlink

--- a/src/collect-tests.sh
+++ b/src/collect-tests.sh
@@ -14,14 +14,46 @@ set -C
 # Script information
 ################################################################################
 
+# Readlink recursively
+# 
+# This can be achieved with `readlink -f` in the GNU command environment,
+# but we implement it independently for mac support.
+#
+# Arguments
+#   $1 - target path
+#
+# Standard Output
+#   the absolute real path
+function itr_readlink() {
+    local target_path=$1
+
+    (
+        cd "$(dirname "$target_path")"
+        target_path=$(basename "$target_path")
+
+        # Iterate down a (possible) chain of symlinks
+        while [ -L "$target_path" ]
+        do
+            target_path=$(readlink "$target_path")
+            cd "$(dirname "$target_path")"
+            target_path=$(basename "$target_path")
+        done
+
+        echo "$(pwd -P)/$target_path"
+    )
+}
+
 # The current directory when this script started.
 ORIGINAL_PWD=$(pwd)
 readonly ORIGINAL_PWD
+# The path of this script file
+SCRIPT_PATH=$(itr_readlink "$0")
+readonly SCRIPT_PATH
 # The directory path of this script file
-SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
+SCRIPT_DIR=$(cd "$(dirname "$SCRIPT_PATH")"; pwd)
 readonly SCRIPT_DIR
 # The path of this script file
-SCRIPT_NAME=$(basename "$0")
+SCRIPT_NAME=$(basename "$SCRIPT_PATH")
 readonly SCRIPT_NAME
 
 # The version number of this application


### PR DESCRIPTION
To allow scripts to work via symbolic links.