### PR TITLE
♻Extract function `abspath` to external files

### DIFF
--- a/src/collect-tests.sh
+++ b/src/collect-tests.sh
@@ -74,6 +74,9 @@ readonly GRADLE_TEST_COLLECTOR_URL
 # Include
 ################################################################################
 
+# shellcheck source=libs/files.sh
+source "$SCRIPT_DIR/libs/files.sh"
+
 # shellcheck source=libs/ana-gradle.sh
 source "$SCRIPT_DIR/libs/ana-gradle.sh"
 
@@ -120,24 +123,6 @@ function echo_info () {
 # any messages should be output to stderr.
 function echo_err() {
     echo "$SCRIPT_NAME: $*" >&2
-}
-
-# Get absolute path
-#
-# Arguments
-#   $1 - base path
-#   $2 - relative path
-#
-# Standard Output
-#   the absolute path
-function abspath() {
-    local -r base_path=$1
-    local -r relative_path=$2
-
-    abs_dir=$(cd "$base_path"; cd "$(dirname "$relative_path")"; pwd)
-    filename=$(basename "$relative_path")
-    
-    echo "$abs_dir/$filename"
 }
 
 # Output the name of the file to be used as the output destination for stdout of gradle task.

--- a/src/libs/files.sh
+++ b/src/libs/files.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+
+# Get absolute path
+#
+# Arguments
+#   $1 - base path
+#   $2 - relative path
+#
+# Standard Output
+#   the absolute path
+function abspath() {
+    local -r base_path=$1
+    local -r relative_path=$2
+
+    abs_dir=$(cd "$base_path" && cd "$(dirname "$relative_path")" && pwd)
+    exit_code=$?
+    if [ $exit_code -ne 0 ]; then
+        return $exit_code
+    fi
+
+    filename=$(basename "$relative_path")
+
+    echo "$abs_dir/$filename"
+}


### PR DESCRIPTION
This change was also made in gradle-dependence-viewer: https://github.com/unaguna/gradle-dependence-viewer/pull/6/commits/7f46be21cfba5a69e595a2edcbe25ba8882ef286